### PR TITLE
fix: Close bookmarks list window if selected item is nil

### DIFF
--- a/lua/bookmarks/list.lua
+++ b/lua/bookmarks/list.lua
@@ -187,6 +187,12 @@ end
 -- jump
 function M.jump(line)
     local item = data.bookmarks[data.bookmarks_order_ids[line]]
+
+    if item == nil then
+        w.close_bookmarks()
+        return
+    end
+
     data.bookmarks[data.bookmarks_order_ids[line]].fre = data.bookmarks[data.bookmarks_order_ids[line]].fre + 1
     data.bookmarks[data.bookmarks_order_ids[line]].updated_at = os.time()
 


### PR DESCRIPTION
If your bookmarks list is empty and you press enter, `list.jump` will error out 

```
E5108: Error executing lua .../pack/packer/start/bookmarks.nvim/lua/bookmarks/list.lua:190: attempt to index a nil value
stack traceback:
        .../pack/packer/start/bookmarks.nvim/lua/bookmarks/list.lua:190: in function 'jump'
        .../site/pack/packer/start/bookmarks.nvim/lua/bookmarks.lua:60: in function 'jump'
        [string ":lua"]:1: in main chunk
```

So i added this to check if `item` is nil (meaning nothing is selected) 
before attempting to index nil value :)


