### PR TITLE
Add highlight group to `virt_text` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ require("bookmarks").setup({
     virt_pattern = { "*.go", "*.lua", "*.sh", "*.php", "*.rust" } -- Show virt text only on matched pattern
 })
 ```
+
+## Highlights
+
+| Highlight               | Purpose                                |
+| ----------------------- | -------------------------------------- |
+| bookmarks_virt_text     | Highlight of the virt_text             |
+
 ## TODO
 - [x] Fix bookmarks when file changed
 - [ ] Categorize

--- a/lua/bookmarks/marks.lua
+++ b/lua/bookmarks/marks.lua
@@ -36,7 +36,7 @@ function M.set_marks(buf, marks)
     -- set new old ext
     for _, mark in ipairs(marks) do
         local ext_id = api.nvim_buf_set_extmark(buf, M.ns_id, mark.line - 1, -1, {
-            virt_text = { { text } },
+            virt_text = { { text, "bookmarks_virt_text" } },
             virt_text_pos = "eol",
             hl_mode = "combine",
         })


### PR DESCRIPTION
added a hl_group name to `virt_text` to make it more customizable

## usage example in my `config`
```lua
vim.api.nvim_set_hl(0, "bookmarks_virt_text", { fg = "#E06C75" })
```

## preview
![image](https://i.imgur.com/1DcGqyz.png)