### PR TITLE
Refactor keymaps

### DIFF
--- a/lua/bookmarks/list.lua
+++ b/lua/bookmarks/list.lua
@@ -17,20 +17,14 @@ end
 
 function M.add_bookmark(line, buf, rows)
     local bufs_pairs = w.open_add_win(line)
-    api.nvim_buf_set_keymap(bufs_pairs.pairs.buf, "n", "<ESC>",
-        string.format(":lua require('bookmarks.window').close_add_win(%d, %d)<cr>", bufs_pairs.pairs.buf,
-            bufs_pairs.border_pairs.buf),
-        { silent = true })
-
-    api.nvim_buf_set_keymap(bufs_pairs.pairs.buf, "i", "<CR>",
-        string.format("<esc><cmd>lua require('bookmarks.list').handle_add(%d, %d, %d, %d, %d)<cr>",
-            line,
-            bufs_pairs.pairs.buf,
-            bufs_pairs.border_pairs.buf,
-            buf,
-            rows
-        ),
-        { silent = true, noremap = true })
+    vim.keymap.set("n", "<ESC>",
+        function() w.close_add_win(bufs_pairs.pairs.buf, bufs_pairs.border_pairs.buf) end,
+        { silent = true, buffer = bufs_pairs.pairs.buf }
+    )
+    vim.keymap.set("i", "<CR>",
+        function() M.handle_add(line, bufs_pairs.pairs.buf, bufs_pairs.border_pairs.buf, buf, rows) end,
+        { silent = true, noremap = true, buffer = bufs_pairs.pairs.buf }
+    )
 end
 
 function M.handle_add(line, buf1, buf2, buf, rows)

--- a/lua/bookmarks/window.lua
+++ b/lua/bookmarks/window.lua
@@ -85,12 +85,10 @@ function M.open_bookmarks()
     data.bufbb = float.create_border(options).buf
 
     api.nvim_buf_set_option(data.bufb, 'filetype', 'bookmarks')
-    api.nvim_buf_set_keymap(data.bufb, "n", config.keymap.jump, ":lua require'bookmarks'.jump()<cr>",
-        { silent = true })
-    api.nvim_buf_set_keymap(data.bufb, "n", config.keymap.delete, ":lua require'bookmarks'.delete()<cr>",
-        { silent = true })
-    api.nvim_buf_set_keymap(data.bufb, "n", config.keymap.order, ":lua require'bookmarks.list'.refresh(true)<cr>",
-        { silent = true })
+    local map_opts = { buffer = data.bufb, silent = true }
+    vim.keymap.set("n", config.keymap.jump, require("bookmarks").jump, map_opts)
+    vim.keymap.set("n", config.keymap.delete, require("bookmarks").delete, map_opts)
+    vim.keymap.set("n", config.keymap.order, function() require("bookmarks.list").refresh(true) end, map_opts)
 
     api.nvim_win_set_option(data.bufbw, "cursorline", true)
     api.nvim_win_set_option(data.bufbw, "wrap", false)


### PR DESCRIPTION
This PR uses `vim.keymap.set()` to also set the buffer keymaps. Since it allows for direct function calls it enables lsp assistance, has a more concise syntax and spares fiddling with strings.