### PR TITLE
Add an option to disable default mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Command:
 
 ```lua
 require("bookmarks").setup({
+    mappings_enabled = true,
     keymap = {
         toggle = "<tab><tab>", -- Toggle bookmarks
         add = "\\z", -- Add bookmarks

--- a/lua/bookmarks/config.lua
+++ b/lua/bookmarks/config.lua
@@ -1,9 +1,10 @@
 local M = {
-    data = nil
+    data = nil,
 }
 
 function M.setup(user_config)
     M.data = {
+        mappings_enabled = true,
         keymap = {
             toggle = "<tab><tab>", -- toggle bookmarks
             add = "\\z", -- add bookmarks
@@ -11,7 +12,7 @@ function M.setup(user_config)
             delete = "dd", -- delete bookmarks
             order = "<space><space>", -- order bookmarks by frequency or updated_time
             delete_on_virt = "\\dd", -- delete bookmark at virt text line
-            show_desc = "\\sd" -- show bookmark desc
+            show_desc = "\\sd", -- show bookmark desc
         },
         width = 0.8, -- bookmarks window width:  (0, 1]
         height = 0.7, -- bookmarks window height: (0, 1]
@@ -20,11 +21,11 @@ function M.setup(user_config)
         fix_enable = false,
         virt_text = "🔖", -- Show virt text at the end of bookmarked lines
         virt_pattern = { "*.go", "*.lua", "*.sh", "*.php", "*.rs" }, -- Show virt text only on matched pattern
-        border_style = "single", -- border style: "single", "double", "rounded" 
+        border_style = "single", -- border style: "single", "double", "rounded"
         hl = {
             border = "TelescopeBorder", -- border highlight
             cursorline = "guibg=Gray guifg=White", -- cursorline highlight
-        }
+        },
     }
 
     if user_config == nil or type(user_config) ~= "table" then
@@ -37,7 +38,7 @@ function M.setup(user_config)
                 M.data[dk] = user_config[dk]
             end
         else
-            for fk, fv in pairs(dv) do
+            for fk, _ in pairs(dv) do
                 if user_config[dk] ~= nil and user_config[dk][fk] ~= nil then
                     M.data[dk][fk] = user_config[dk][fk]
                 end

--- a/lua/bookmarks/event.lua
+++ b/lua/bookmarks/event.lua
@@ -7,7 +7,9 @@ local api = vim.api
 
 function M.setup()
     config = require("bookmarks.config").get_data()
-    M.key_bind()
+    if config.mappings_enabled then
+        M.key_bind()
+    end
     M.autocmd()
 end
 

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,3 @@
+indent_width = 4
+column_width = 130
+indent_type = "Spaces"


### PR DESCRIPTION
This PR add an option `mappings_enabled` to setup section.
This is needed for users who want to map the keys themselves.
The basic behavior does not change due to the fact that the setting is enabled by default.

Also, I've added a configuration for [stylua](https://github.com/JohnnyMorganz/StyLua), with defaults appropriate for project c: