### PR TITLE
Fix: errors while pressing c-j

### DIFF
--- a/lua/bookmarks/window.lua
+++ b/lua/bookmarks/window.lua
@@ -131,7 +131,7 @@ function M.open_bookmarks()
         "n",
         "<c-j>",
         function() api.nvim_set_current_win(data.buftw) end,
-        { silent = true, noremap = true, buffer = data.buft }
+        { silent = true, noremap = true, buffer = data.bufb }
     )
 
     M.open_tags()


### PR DESCRIPTION
`<C-j>` works in the buffer of the bookmark window. Otherwise, the error appears while pressing `<c-j>`.

partially address https://github.com/crusj/bookmarks.nvim/issues/27