### PR TITLE
feat(bookmark-window): add key mappings related to focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ require("bookmarks").setup({
         order = "<space><space>", -- Order bookmarks by frequency or updated_time(buf keymap)
         delete_on_virt = "\\dd", -- Delete bookmark at virt text line(global keymap)
         show_desc = "\\sd", -- show bookmark desc(global keymap)
+        toogle_focus = "<S-Tab>", -- toggle window focus (tags-win <-> bookmarks-win)
     },
     width = 0.8, -- Bookmarks window width:  (0, 1]
     height = 0.7, -- Bookmarks window height: (0, 1]

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ require("bookmarks").setup({
         order = "<space><space>", -- Order bookmarks by frequency or updated_time(buf keymap)
         delete_on_virt = "\\dd", -- Delete bookmark at virt text line(global keymap)
         show_desc = "\\sd", -- show bookmark desc(global keymap)
-        toogle_focus = "<S-Tab>", -- toggle window focus (tags-win <-> bookmarks-win)
+        focus_tags = "<c-j>",      -- focus tags window
+        focus_bookmarks = "<c-k>", -- focus bookmarks window
+        toogle_focus = "<S-Tab>", -- toggle window focus (tags-window <-> bookmarks-window)
     },
     width = 0.8, -- Bookmarks window width:  (0, 1]
     height = 0.7, -- Bookmarks window height: (0, 1]
@@ -165,7 +167,8 @@ Tags is now supported to categorize bookmarks. You can add tags to your bookmark
 
 By default, ALL bookmarks are marked as ALL tags.
 
-You can use the shortcut keys `<c-j>` and `<c-k>` to jump through the Tags window and the bookmarks window.
+You can use the shortcut key `<S-Tab>` to switch the focus between the Tags and Bookmarks windows, or use the shortcut keys `<c-j>` and `<c-k>` to navigate through the Tags and Bookmarks windows.
+> Of course, you can change these default shortcut keys through the configuration settings if you so choose.
 
 ## Issue
 

--- a/lua/bookmarks/config.lua
+++ b/lua/bookmarks/config.lua
@@ -14,6 +14,8 @@ function M.setup(user_config)
             order = "<space><space>", -- order bookmarks by frequency or updated_time
             delete_on_virt = "\\dd",  -- delete bookmark at virt text line
             show_desc = "\\sd",       -- show bookmark desc
+            focus_tags = "<c-j>",      -- focus tags window
+            focus_bookmarks = "<c-k>", -- focus bookmarks window
             toogle_focus = "<S-Tab>", -- toggle window focus (tags-win <-> bookmarks-win)
         },
         width = 0.8,                  -- bookmarks window width:  (0, 1]

--- a/lua/bookmarks/config.lua
+++ b/lua/bookmarks/config.lua
@@ -14,6 +14,7 @@ function M.setup(user_config)
             order = "<space><space>", -- order bookmarks by frequency or updated_time
             delete_on_virt = "\\dd",  -- delete bookmark at virt text line
             show_desc = "\\sd",       -- show bookmark desc
+            toogle_focus = "<S-Tab>", -- toggle window focus (tags-win <-> bookmarks-win)
         },
         width = 0.8,                  -- bookmarks window width:  (0, 1]
         height = 0.7,                 -- bookmarks window height: (0, 1]

--- a/lua/bookmarks/config.lua
+++ b/lua/bookmarks/config.lua
@@ -16,7 +16,7 @@ function M.setup(user_config)
             show_desc = "\\sd",       -- show bookmark desc
             focus_tags = "<c-j>",      -- focus tags window
             focus_bookmarks = "<c-k>", -- focus bookmarks window
-            toogle_focus = "<S-Tab>", -- toggle window focus (tags-win <-> bookmarks-win)
+            toogle_focus = "<S-Tab>", -- toggle window focus (tags-window <-> bookmarks-window)
         },
         width = 0.8,                  -- bookmarks window width:  (0, 1]
         height = 0.7,                 -- bookmarks window height: (0, 1]

--- a/lua/bookmarks/window.lua
+++ b/lua/bookmarks/window.lua
@@ -48,6 +48,8 @@ function M.setup()
     config = require("bookmarks.config").get_data()
     vim.cmd(string.format("highlight hl_bookmarks_csl %s", config.hl.cursorline))
     float.setup()
+    focus_manager.register("tags")
+    focus_manager.register("bookmarks")
 end
 
 -- calculate window size.
@@ -197,7 +199,6 @@ function M.open_bookmarks()
     api.nvim_set_current_win(data.bufbw)
     bookmarks_autocmd(data.bufb)
 
-    focus_manager.register("bookmarks")
     focus_manager.set("bookmarks", data.bufbw)
     focus_manager.update_current("bookmarks") -- set default focus win
 
@@ -270,7 +271,6 @@ function M.open_tags()
     data.buftw = pair.win
     data.buftb = float.create_border(options).buf
     api.nvim_buf_set_option(pair.buf, 'filetype', 'btags')
-    focus_manager.register("tags")
     focus_manager.set("tags", data.buftw)
 
     local set_key_opts = { silent = true, noremap = true, buffer = data.buft }

--- a/lua/bookmarks/window.lua
+++ b/lua/bookmarks/window.lua
@@ -205,7 +205,7 @@ function M.open_bookmarks()
     M.open_tags()
     vim.keymap.set(
         "n",
-        "<c-j>",
+        config.keymap.focus_tags,
         function()
             if api.nvim_win_is_valid(data.buftw) then
                 api.nvim_set_current_win(data.buftw)
@@ -294,7 +294,7 @@ function M.open_tags()
     )
     vim.keymap.set(
         "n",
-        "<c-k>",
+        config.keymap.focus_bookmarks,
         function()
             api.nvim_set_current_win(data.bufbw)
             focus_manager.update_current("bookmarks")

--- a/lua/bookmarks/window.lua
+++ b/lua/bookmarks/window.lua
@@ -26,10 +26,15 @@ local focus_manager = (function()
 
         if next_type == nil then next_type = win_types[1] end
 
-        local win = wins[next_type]
-        assert(win ~= nil, "win is nil")
+        local next_win = wins[next_type]
+        if next_win == nil then
+            local msg = string.format("%s window not found", next_type)
+            vim.notify(msg, vim.log.levels.INFO, { title = "bookmarks.nvim" })
+            return
+        end
+
         current_type = next_type
-        api.nvim_set_current_win(win)
+        api.nvim_set_current_win(next_win)
     end
 
     return {

--- a/lua/bookmarks/window.lua
+++ b/lua/bookmarks/window.lua
@@ -10,7 +10,7 @@ local focus_manager = (function()
     --- @alias WinType string
     --- @alias WinId integer 
     local current_type = nil --- @type WinType | nil
-    local win_types = {} --- @type table<integer, WinType>
+    local win_types = {} --- @type WinType[]
     local wins = {} --- @type table<WinType, WinId>
 
     local function toogle()
@@ -37,8 +37,8 @@ local focus_manager = (function()
         update_current = function(type) current_type = type end,
         set = function(type, win) wins[type] = win end,
         register = function(type)
-          local exist = vim.tbl_contains(win_types, type)
-          if not exist then table.insert(win_types, type) end
+            local exist = vim.tbl_contains(win_types, type)
+            if not exist then table.insert(win_types, type) end
         end,
     }
 end)()


### PR DESCRIPTION
1. Add `toggle_focus` key
This allows for quick switching between `tags-window` and `bookmarks-window`.
> PS: Of course, the specific implementation can easily include the `preview-window`.

2. Add focus key mappings for `tags-window` and `bookmarks-window`
The default `<c-j>`, `<c-k>` may not necessarily cater to everyone's preferences. For instance, I am one of them :)
